### PR TITLE
Update openrc.example with notes and an extra alias

### DIFF
--- a/openrc.example
+++ b/openrc.example
@@ -1,16 +1,31 @@
-export OS_USERNAME=obvs
-export OS_PASSWORD=obvs
-export OS_PROJECT_NAME=project not the contract
-export OS_PROJECT_ID=from api url hex
-export OS_AUTH_URL=https://identity.uk-1.cloud.global.fujitsu.com/v3
+# These are the "Real" credentials you've been supplied from the PMO
+export OS_USERNAME=
+export OS_PASSWORD=
+# This is the name of the Region you log into 
 export OS_REGION_NAME=uk-1
-export OS_VOLUME_API_VERSION=2
-export OS_IDENTITY_API_VERSION=3
-export OS_USER_DOMAIN_NAME=contract id
-export OS_DEFAULT_DOMAIN=contract id
+# This is the name of the "Contract" you log into
+export OS_USER_DOMAIN_NAME=
+
+# This is the name of the project you're applying this against
+export OS_PROJECT_NAME=""
+# Get this from the "API Access" tab on the "Access and Security" page.
+# It's the suffix of many of the API endpoints - e.g. orchestration, blockstorage
+export OS_PROJECT_ID=
+# This is more tricky to get, but if you go to the "Manage" -> "Project" page
+# it will bring up an error message. Click through to see the details
+# and this is where the domain ID is... or just ask the PMO
+export OS_DEFAULT_DOMAIN=
 
 # for extra debug in the k5_ modules
 export K5_DEBUG=1
 
+# These are "blanket" versions for K5
+export OS_AUTH_URL=https://identity.uk-1.cloud.global.fujitsu.com/v3
+export OS_VOLUME_API_VERSION=2
+export OS_IDENTITY_API_VERSION=3
+
 # clean up
-alias clean-k5-envvars="env|grep OS_ ; unset $(env | awk -F= '/OS_/ {print $1}' | xargs); env|grep OS_ 
+alias clean-k5-envvars="env|grep [KO][5S]_ | grep -v PASSWORD ; unset $(env | awk -F= '/[KO][5S]_/ {print $1}' | xargs); env|grep [KO][5S]_ "
+
+# Check which openrc values you have currently configured
+alias show-k5-envvars="env|grep [KO][5S]_ | grep -v PASSWORD"


### PR DESCRIPTION
* Added comments about where to find these values
* Removed "obvs" and replaced with empty strings
* Separated the file out into a slightly easier to parse format
* Added "| grep -v PASSWORD" so running the clean-k5-envvars doesn't inadvertently render your password
* Added new alias show-k5-envvars so you can quickly check which K5 you're configured for